### PR TITLE
bug: updated readme setup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you're using this code from a Git repository, clone it to your local machine:
 
 ```bash
 git clone https://github.com/contawo/bash_calculator.git
-cd bash-calculator
+cd bash_calculator
 ```
 
 ### 3. **Locate the `/usr/bin` Directory**


### PR DESCRIPTION
The code had was `cd bash-calculator` and I changed it to `bash_calculator`.